### PR TITLE
Fix windows support.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashSet,
     convert::TryFrom,
     env::current_dir,
     fs::{read_dir, read_to_string, File},
@@ -9,7 +10,7 @@ use std::{
 use structopt::StructOpt;
 
 #[cfg(not(windows))]
-use std::{collections::HashSet, fs::Permissions, os::unix::fs::PermissionsExt};
+use std::{fs::Permissions, os::unix::fs::PermissionsExt};
 
 mod args;
 use args::{Args, Subcommand};


### PR DESCRIPTION
This got broken after a few days.

If not obvious, the `#[cfg(not(windows))]` block is only for things that are absolutely not supported on Windows, like the concept of UNIX modes, for which there is no equivalent. Windows uses ACLs exclusively, and the current user defaults to full control (including execute) for files it creates.

No such limitations on HashSet that I'm aware of.